### PR TITLE
Fixed memory alignment error

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -4,12 +4,11 @@ use test::Bencher;
 
 const RB_SIZE: usize = 0x400;
 
-
 #[bench]
 fn single_item(b: &mut Bencher) {
     let buf = RingBuffer::<u64>::new(RB_SIZE);
     let (mut prod, mut cons) = buf.split();
-    prod.push_slice(&[1; RB_SIZE/2]);
+    prod.push_slice(&[1; RB_SIZE / 2]);
     b.iter(|| {
         prod.push(1).unwrap();
         cons.pop().unwrap();
@@ -20,7 +19,7 @@ fn single_item(b: &mut Bencher) {
 fn slice_x10(b: &mut Bencher) {
     let buf = RingBuffer::<u64>::new(RB_SIZE);
     let (mut prod, mut cons) = buf.split();
-    prod.push_slice(&[1; RB_SIZE/2]);
+    prod.push_slice(&[1; RB_SIZE / 2]);
     let mut data = [1; 10];
     b.iter(|| {
         prod.push_slice(&data);
@@ -32,7 +31,7 @@ fn slice_x10(b: &mut Bencher) {
 fn slice_x100(b: &mut Bencher) {
     let buf = RingBuffer::<u64>::new(RB_SIZE);
     let (mut prod, mut cons) = buf.split();
-    prod.push_slice(&[1; RB_SIZE/2]);
+    prod.push_slice(&[1; RB_SIZE / 2]);
     let mut data = [1; 100];
     b.iter(|| {
         prod.push_slice(&data);

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -218,7 +218,7 @@ impl<T: Sized> Consumer<T> {
                 };
                 for (i, dst) in left[0..lb].iter_mut().enumerate() {
                     if !f(mem::replace(dst, MaybeUninit::uninit()).assume_init()) {
-                        return i;
+                        return i + 1;
                     }
                 }
                 if lb < left.len() {
@@ -231,7 +231,7 @@ impl<T: Sized> Consumer<T> {
                 };
                 for (i, dst) in right[0..rb].iter_mut().enumerate() {
                     if !f(mem::replace(dst, MaybeUninit::uninit()).assume_init()) {
-                        return i + lb;
+                        return i + lb + 1;
                     }
                 }
                 left.len() + right.len()

--- a/src/tests/drop.rs
+++ b/src/tests/drop.rs
@@ -139,17 +139,16 @@ fn multiple_each() {
 
 /// Test the `pop_each` with internal function that returns false
 #[test]
-fn pop_each_test1(){
-
+fn pop_each_test1() {
     let cap = 10usize;
     let (mut producer, mut consumer) = RingBuffer::new(cap).split();
 
-    for i in 0..cap{
+    for i in 0..cap {
         producer.push((i, vec![0u8; 1000])).unwrap();
     }
 
-    for _ in 0..cap{
-        let removed = consumer.pop_each(|_val| -> bool{false}, None);
+    for _ in 0..cap {
+        let removed = consumer.pop_each(|_val| -> bool { false }, None);
         assert_eq!(removed, 1);
     }
 
@@ -158,17 +157,16 @@ fn pop_each_test1(){
 
 /// Test the `pop_each` with capped pop
 #[test]
-fn pop_each_test2(){
-
+fn pop_each_test2() {
     let cap = 10usize;
     let (mut producer, mut consumer) = RingBuffer::new(cap).split();
 
-    for i in 0..cap{
+    for i in 0..cap {
         producer.push((i, vec![0u8; 1000])).unwrap();
     }
 
-    for _ in 0..cap{
-        let removed = consumer.pop_each(|_val| -> bool{true}, Some(1));
+    for _ in 0..cap {
+        let removed = consumer.pop_each(|_val| -> bool { true }, Some(1));
         assert_eq!(removed, 1);
     }
 
@@ -177,8 +175,7 @@ fn pop_each_test2(){
 
 /// Test the `push_each` with internal function that adds only 1 element.
 #[test]
-fn push_each_test1(){
-
+fn push_each_test1() {
     let cap = 10usize;
     let (mut producer, mut consumer) = RingBuffer::new(cap).split();
 
@@ -189,14 +186,14 @@ fn push_each_test1(){
             if count == 0 {
                 count += 1;
                 Some((i, vec![0u8; 1000]))
-            }else{
+            } else {
                 None
             }
         });
         assert_eq!(added, 1);
     }
 
-    for _ in 0..cap{
+    for _ in 0..cap {
         consumer.pop().unwrap();
     }
 
@@ -205,19 +202,18 @@ fn push_each_test1(){
 
 /// Test the `push_each` with split internal buffer
 #[test]
-fn push_each_test2(){
-
+fn push_each_test2() {
     let cap = 10usize;
     let cap_half = 5usize;
     let (mut producer, mut consumer) = RingBuffer::new(cap).split();
 
     // Fill the entire buffer
-    for i in 0..cap{
+    for i in 0..cap {
         producer.push((i, vec![0u8; 1000])).unwrap();
     }
 
     // Remove half elements
-    for _ in 0..cap_half{
+    for _ in 0..cap_half {
         consumer.pop().unwrap();
     }
 
@@ -229,14 +225,14 @@ fn push_each_test2(){
             if count == 0 {
                 count += 1;
                 Some((i, vec![0u8; 1000]))
-            }else{
+            } else {
                 None
             }
         });
         assert_eq!(added, 1);
     }
 
-    for _ in 0..cap{
+    for _ in 0..cap {
         consumer.pop().unwrap();
     }
 

--- a/src/tests/drop.rs
+++ b/src/tests/drop.rs
@@ -136,3 +136,109 @@ fn multiple_each() {
 
     assert_eq!(set.borrow().len(), 0);
 }
+
+/// Test the `pop_each` with internal function that returns false
+#[test]
+fn pop_each_test1(){
+
+    let cap = 10usize;
+    let (mut producer, mut consumer) = RingBuffer::new(cap).split();
+
+    for i in 0..cap{
+        producer.push((i, vec![0u8; 1000])).unwrap();
+    }
+
+    for _ in 0..cap{
+        let removed = consumer.pop_each(|_val| -> bool{false}, None);
+        assert_eq!(removed, 1);
+    }
+
+    assert_eq!(consumer.len(), 0);
+}
+
+/// Test the `pop_each` with capped pop
+#[test]
+fn pop_each_test2(){
+
+    let cap = 10usize;
+    let (mut producer, mut consumer) = RingBuffer::new(cap).split();
+
+    for i in 0..cap{
+        producer.push((i, vec![0u8; 1000])).unwrap();
+    }
+
+    for _ in 0..cap{
+        let removed = consumer.pop_each(|_val| -> bool{true}, Some(1));
+        assert_eq!(removed, 1);
+    }
+
+    assert_eq!(consumer.len(), 0);
+}
+
+/// Test the `push_each` with internal function that adds only 1 element.
+#[test]
+fn push_each_test1(){
+
+    let cap = 10usize;
+    let (mut producer, mut consumer) = RingBuffer::new(cap).split();
+
+    for i in 0..cap {
+        let mut count = 0;
+        // Add 1 element at a time
+        let added = producer.push_each(|| -> Option<(usize, Vec<u8>)> {
+            if count == 0 {
+                count += 1;
+                Some((i, vec![0u8; 1000]))
+            }else{
+                None
+            }
+        });
+        assert_eq!(added, 1);
+    }
+
+    for _ in 0..cap{
+        consumer.pop().unwrap();
+    }
+
+    assert_eq!(consumer.len(), 0);
+}
+
+/// Test the `push_each` with split internal buffer
+#[test]
+fn push_each_test2(){
+
+    let cap = 10usize;
+    let cap_half = 5usize;
+    let (mut producer, mut consumer) = RingBuffer::new(cap).split();
+
+    // Fill the entire buffer
+    for i in 0..cap{
+        producer.push((i, vec![0u8; 1000])).unwrap();
+    }
+
+    // Remove half elements
+    for _ in 0..cap_half{
+        consumer.pop().unwrap();
+    }
+
+    // Re add half elements one by one and check the return count.
+    for i in 0..cap_half {
+        let mut count = 0;
+        // Add 1 element at a time
+        let added = producer.push_each(|| -> Option<(usize, Vec<u8>)> {
+            if count == 0 {
+                count += 1;
+                Some((i, vec![0u8; 1000]))
+            }else{
+                None
+            }
+        });
+        assert_eq!(added, 1);
+    }
+
+    for _ in 0..cap{
+        consumer.pop().unwrap();
+    }
+
+    assert_eq!(consumer.len(), 0);
+}


### PR DESCRIPTION
- Fixed memory alignment error when the `pop_each` function is used.
- Added some tests to check it.
- Cargo fmt