### PR TITLE
Fix `pop_each`

### DIFF
--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -243,10 +243,10 @@ impl<T: Sized> Consumer<T> {
                 };
                 for (i, dst) in right[0..rb].iter_mut().enumerate() {
                     if !f(mem::replace(dst, MaybeUninit::uninit()).assume_init()) {
-                        return i + lb + 1;
+                        return lb + i + 1;
                     }
                 }
-                left.len() + right.len()
+                lb + rb
             })
         }
     }

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -229,7 +229,7 @@ impl<T: Sized> Consumer<T> {
                     None => left.len(),
                 };
                 for (i, dst) in left[0..lb].iter_mut().enumerate() {
-                    if !f(mem::replace(dst, MaybeUninit::uninit()).assume_init()) {
+                    if !f(dst.as_ptr().read()) {
                         return i + 1;
                     }
                 }
@@ -242,7 +242,7 @@ impl<T: Sized> Consumer<T> {
                     None => right.len(),
                 };
                 for (i, dst) in right[0..rb].iter_mut().enumerate() {
-                    if !f(mem::replace(dst, MaybeUninit::uninit()).assume_init()) {
+                    if !f(dst.as_ptr().read()) {
                         return lb + i + 1;
                     }
                 }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -175,13 +175,13 @@ impl<T: Sized> Producer<T> {
             self.push_access(|left, right| {
                 for (i, dst) in left.iter_mut().enumerate() {
                     match f() {
-                        Some(e) => mem::replace(dst, MaybeUninit::new(e)),
+                        Some(e) => dst.as_mut_ptr().write(e),
                         None => return i,
                     };
                 }
                 for (i, dst) in right.iter_mut().enumerate() {
                     match f() {
-                        Some(e) => mem::replace(dst, MaybeUninit::new(e)),
+                        Some(e) => dst.as_mut_ptr().write(e),
                         None => return i + left.len(),
                     };
                 }

--- a/src/ring_buffer.rs
+++ b/src/ring_buffer.rs
@@ -1,13 +1,13 @@
+use crate::{consumer::Consumer, producer::Producer};
 use alloc::{sync::Arc, vec::Vec};
+use cache_padded::CachePadded;
 use core::{
     cell::UnsafeCell,
     cmp::min,
-    mem::{self, MaybeUninit},
+    mem::MaybeUninit,
     ptr::{self, copy},
     sync::atomic::{AtomicUsize, Ordering},
 };
-use cache_padded::CachePadded;
-use crate::{consumer::Consumer, producer::Producer};
 
 pub(crate) struct SharedVec<T: Sized> {
     cell: UnsafeCell<Vec<T>>,

--- a/src/ring_buffer.rs
+++ b/src/ring_buffer.rs
@@ -102,7 +102,7 @@ impl<T: Sized> Drop for RingBuffer<T> {
         };
 
         let drop = |elem_ref: &mut MaybeUninit<T>| unsafe {
-            mem::replace(elem_ref, MaybeUninit::uninit()).assume_init();
+            elem_ref.as_ptr().read();
         };
         for elem in data[slices.0].iter_mut() {
             drop(elem);

--- a/src/tests/multiple.rs
+++ b/src/tests/multiple.rs
@@ -45,6 +45,59 @@ fn for_each_mut() {
 }
 
 #[test]
+fn pop_each() {
+    let cap = 3;
+    let buf = RingBuffer::<i32>::new(cap);
+    let (mut prod, mut cons) = buf.split();
+
+    prod.push(10).unwrap();
+    prod.push(20).unwrap();
+
+    let mut sum_1 = 0;
+    cons.pop_each(
+        |v| {
+            sum_1 += v;
+            v != 20
+        },
+        Some(2),
+    );
+
+    prod.push(30).unwrap();
+    prod.push(40).unwrap();
+    prod.push(50).unwrap();
+
+    cons.pop_each(
+        |v| {
+            sum_1 += v;
+            true
+        },
+        Some(2),
+    );
+
+    prod.push(60).unwrap();
+
+    cons.pop_each(
+        |v| {
+            sum_1 += v;
+            v != 50
+        },
+        None,
+    );
+
+    prod.push(70).unwrap();
+
+    cons.pop_each(
+        |v| {
+            sum_1 += v;
+            true
+        },
+        Some(2),
+    );
+
+    assert_eq!(sum_1, 10 + 20 + 30 + 40 + 50 + 60 + 70);
+}
+
+#[test]
 fn push_pop_slice() {
     let buf = RingBuffer::<i32>::new(4);
     let (mut prod, mut cons) = buf.split();


### PR DESCRIPTION
`pop_each` is wrongfully over-consuming elements in the edge case that `n` is larger than `left.len()` but smaller than `left.len() + right.len()`.

The actual fix is the one-liner on line 249 in `consumer.rs`, but I've taken the liberty to change some `mem::replace` usages for `ptr::write` and `ptr::read` too, to help with performance in debug builds and/or ease the job of the optimizer. Feel free to revert those.
