### PR TITLE
Add iterator implementations and do not rely on call backs so much

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ benchmark = []
 
 [[example]]
 name = "simple"
+
 [[example]]
 name = "message"
 required-features = ["std"]

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -64,49 +64,41 @@ impl<T: Sized> Consumer<T> {
         }
     }
 
-    /// Gives immutable access to the elements contained by the ring buffer without removing them.
-    ///
-    /// The method takes a function `f` as argument.
-    /// `f` takes two slices of ring buffer content (the second one or both of them may be empty).
-    /// First slice contains older elements.
+    /// Returns a pair of slices which contain, in order, the contents of the `RingBuffer`.
     ///
     /// *The slices may not include elements pushed to the buffer by concurring producer after the method call.*
-    pub fn access<F: FnOnce(&[T], &[T])>(&self, f: F) {
+    pub fn as_slices(&self) -> (&[T], &[T]) {
         let ranges = self.get_ranges();
 
         unsafe {
             let left = &self.rb.data.get_ref()[ranges.0];
             let right = &self.rb.data.get_ref()[ranges.1];
 
-            f(
+            (
                 &*(left as *const [MaybeUninit<T>] as *const [T]),
                 &*(right as *const [MaybeUninit<T>] as *const [T]),
-            );
+            )
         }
     }
 
-    /// Gives mutable access to the elements contained by the ring buffer without removing them.
-    ///
-    /// The method takes a function `f` as argument.
-    /// `f` takes two slices of ring buffer content (the second one or both of them may be empty).
-    /// First slice contains older elements.
+    /// Returns a pair of slices which contain, in order, the contents of the `RingBuffer`.
     ///
     /// *The iteration may not include elements pushed to the buffer by concurring producer after the method call.*
-    pub fn access_mut<F: FnOnce(&mut [T], &mut [T])>(&mut self, f: F) {
+    pub fn as_mut_slices(&mut self) -> (&mut [T], &mut [T]) {
         let ranges = self.get_ranges();
 
         unsafe {
             let left = &mut self.rb.data.get_mut()[ranges.0];
             let right = &mut self.rb.data.get_mut()[ranges.1];
 
-            f(
+            (
                 &mut *(left as *mut [MaybeUninit<T>] as *mut [T]),
                 &mut *(right as *mut [MaybeUninit<T>] as *mut [T]),
-            );
+            )
         }
     }
 
-    /// Allows to read from ring buffer memory directry.
+    /// Allows to read from ring buffer memory directly.
     ///
     /// *This function is unsafe because it gives access to possibly uninitialized memory*
     ///
@@ -159,7 +151,7 @@ impl<T: Sized> Consumer<T> {
     ///
     /// The `elems` slice should contain **un-initialized** data before the method call.
     /// After the call the copied part of data in `elems` should be interpreted as **initialized**.
-    /// The remaining part is still **un-iniitilized**.
+    /// The remaining part is still **un-initialized**.
     ///
     /// Returns the number of items been copied.
     ///
@@ -255,28 +247,42 @@ impl<T: Sized> Consumer<T> {
     ///
     /// *The iteration may not include elements pushed to the buffer by concurring producer after the method call.*
     pub fn for_each<F: FnMut(&T)>(&self, mut f: F) {
-        self.access(|left, right| {
-            for c in left.iter() {
-                f(c);
-            }
-            for c in right.iter() {
-                f(c);
-            }
-        });
+        let (left, right) = self.as_slices();
+
+        for c in left.iter() {
+            f(c);
+        }
+        for c in right.iter() {
+            f(c);
+        }
+    }
+
+    /// Returns a front-to-back iterator.
+    pub fn iter(&self) -> impl Iterator<Item = &T> + '_ {
+        let (left, right) = self.as_slices();
+
+        left.iter().chain(right.iter())
     }
 
     /// Iterate mutably over the elements contained by the ring buffer without removing them.
     ///
     /// *The iteration may not include elements pushed to the buffer by concurring producer after the method call.*
     pub fn for_each_mut<F: FnMut(&mut T)>(&mut self, mut f: F) {
-        self.access_mut(|left, right| {
-            for c in left.iter_mut() {
-                f(c);
-            }
-            for c in right.iter_mut() {
-                f(c);
-            }
-        });
+        let (left, right) = self.as_mut_slices();
+
+        for c in left.iter_mut() {
+            f(c);
+        }
+        for c in right.iter_mut() {
+            f(c);
+        }
+    }
+
+    /// Returns a front-to-back iterator that returns mutable references.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> + '_ {
+        let (left, right) = self.as_mut_slices();
+
+        left.iter_mut().chain(right.iter_mut())
     }
 
     /// Removes `n` items from the buffer and safely drops them.
@@ -338,7 +344,7 @@ impl Consumer<u8> {
     /// a [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) instance.
     /// If `count` is `None` then as much as possible bytes will be written.
     ///
-    /// Returns `Ok(n)` if `write` is succeded. `n` is number of bytes been written.
+    /// Returns `Ok(n)` if `write` succeeded. `n` is number of bytes been written.
     /// `n == 0` means that either `write` returned zero or ring buffer is empty.
     ///
     /// If `write` is failed or returned an invalid number then error is returned.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@
 //! `RingBuffer` is the initial structure representing ring buffer itself.
 //! Ring buffer can be splitted into pair of `Producer` and `Consumer`.
 //!
-//! `Producer` and `Consumer` are used to append/remove elements to/from the ring buffer accordingly. They can be safely transfered between threads.
-//! Operations with `Producer` and `Consumer` are lock-free - they're succeded or failed immediately without blocking or waiting.
+//! `Producer` and `Consumer` are used to append/remove elements to/from the ring buffer accordingly. They can be safely sent between threads.
+//! Operations with `Producer` and `Consumer` are lock-free - they succeed or fail immediately without blocking or waiting.
 //!
 //! Elements can be effectively appended/removed one by one or many at once.
 //! Also data could be loaded/stored directly into/from [`Read`]/[`Write`] instances.

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -50,7 +50,7 @@ impl<T: Sized> Producer<T> {
         self.rb.remaining()
     }
 
-    /// Allows to write into ring buffer memory directry.
+    /// Allows to write into ring buffer memory directly.
     ///
     /// *This function is unsafe because it gives access to possibly uninitialized memory*
     ///
@@ -145,7 +145,7 @@ impl<T: Sized> Producer<T> {
     }
 
     /// Appends an element to the ring buffer.
-    /// On failure returns an error containing the element that hasn't beed appended.
+    /// On failure returns an error containing the element that hasn't been appended.
     pub fn push(&mut self, elem: T) -> Result<(), T> {
         let mut elem_mu = MaybeUninit::new(elem);
         let n = unsafe {
@@ -225,7 +225,7 @@ impl Producer<u8> {
     /// and appends them to the ring buffer.
     /// If `count` is `None` then as much as possible bytes will be read.
     ///
-    /// Returns `Ok(n)` if `read` is succeded. `n` is number of bytes been read.
+    /// Returns `Ok(n)` if `read` succeeded. `n` is number of bytes been read.
     /// `n == 0` means that either `read` returned zero or ring buffer is full.
     ///
     /// If `read` is failed or returned an invalid number then error is returned.

--- a/src/tests/iter.rs
+++ b/src/tests/iter.rs
@@ -1,0 +1,37 @@
+use crate::RingBuffer;
+
+#[test]
+fn iter() {
+    let buf = RingBuffer::<i32>::new(2);
+    let (mut prod, mut cons) = buf.split();
+
+    prod.push(10).unwrap();
+    prod.push(20).unwrap();
+
+    let sum: i32 = cons.iter().sum();
+
+    let first = cons.pop().expect("First element not available");
+    let second = cons.pop().expect("Second element not available");
+
+    assert_eq!(sum, first + second);
+}
+
+#[test]
+fn iter_mut() {
+    let buf = RingBuffer::<i32>::new(2);
+    let (mut prod, mut cons) = buf.split();
+
+    prod.push(10).unwrap();
+    prod.push(20).unwrap();
+
+    for v in cons.iter_mut() {
+        *v *= 2;
+    }
+
+    let sum: i32 = cons.iter().sum();
+
+    let first = cons.pop().expect("First element not available");
+    let second = cons.pop().expect("Second element not available");
+
+    assert_eq!(sum, first + second);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod access;
 mod drop;
+mod iter;
 #[cfg(feature = "std")]
 mod message;
 mod multiple;


### PR DESCRIPTION
The current implementation relies heavily on callback functions for the consumer:
- [`access`]
- [`access_mut`]
- [`for_each`]
- [`for_each_mut`]
- [`pop_each`]

All of the above use callbacks to return data. Many of these could be made redundant (mainly [`for_each`] and [`for_each_mut`]) by adding an `iter` and `iter_mut` method to the `Consumer` that will allow users of the crate to make use of the whole suite of methods available on iterators. Some of those improvements can be seen in the test cases for these new changes, `src/tests/iter.rs`.

Adding `iter` and `iter_mut` would not constitute themselves as a breaking change, but to be able to implement them, I changed the functions [`access`] and [`access_mut`] to be `as_slices` and `as_mut_slices` to match the functions of the same name on [`std::collections::VecDeque`](https://doc.rust-lang.org/stable/std/collections/struct.VecDeque.html#method.as_slices)

The above change is breaking and drastically changes the api of the `Consumer` so I would understand if you would want the [`access`] and [`access_mut`] functions returned at least.

These initial changes are just to add the `iter` and `iter_mut` functions as I require them in my use of this library, but having looked over the codebase, it looks like a lot of other functions that use callbacks like [`for_each`], [`for_each_mut`], and maybe even [`pop_each`] can be removed in favor of using built-in iterator methods. Not to mention that I have not touched or even looked at the methods on the `Producer`

[`access`]: https://docs.rs/ringbuf/0.2.6/ringbuf/struct.Consumer.html#method.access
[`access_mut`]: https://docs.rs/ringbuf/0.2.6/ringbuf/struct.Consumer.html#method.access_mut
[`for_each`]: https://docs.rs/ringbuf/0.2.6/ringbuf/struct.Consumer.html#method.for_each
[`for_each_mut`]: https://docs.rs/ringbuf/0.2.6/ringbuf/struct.Consumer.html#method.for_each_mut
[`pop_each`]: https://docs.rs/ringbuf/0.2.6/ringbuf/struct.Consumer.html#method.pop_each