### PR TITLE
Fix undefined behaviors

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -2,6 +2,7 @@ use alloc::sync::Arc;
 use core::{
     mem::{self, MaybeUninit},
     ptr::copy_nonoverlapping,
+    slice,
     sync::atomic::Ordering,
 };
 #[cfg(feature = "std")]
@@ -91,9 +92,11 @@ impl<T: Sized> Producer<T> {
             (0..0, 0..0)
         };
 
+        let ptr = self.rb.data.get_mut().as_mut_ptr();
+
         let slices = (
-            &mut self.rb.data.get_mut()[ranges.0],
-            &mut self.rb.data.get_mut()[ranges.1],
+            slice::from_raw_parts_mut(ptr.wrapping_add(ranges.0.start), ranges.0.len()),
+            slice::from_raw_parts_mut(ptr.wrapping_add(ranges.1.start), ranges.1.len()),
         );
 
         let n = f(slices.0, slices.1);


### PR DESCRIPTION
This fixes aliasing issues when two non-overlapping mutable references are needed.

The solution was to derive them from the same `*mut` variable and use `slice::from_raw_parts_mut`.

fixes #15