### PR TITLE
Replace cache-padded with crossbeam-utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ std = ["alloc"]
 bench = []
 
 [dependencies]
-cache-padded = "1.2.0"
+crossbeam-utils = { version = "0.8.11", default-features = false }
 
 [[example]]
 name = "simple"

--- a/src/ring_buffer/shared.rs
+++ b/src/ring_buffer/shared.rs
@@ -1,12 +1,12 @@
 use super::{Container, Rb, RbBase, RbRead, RbWrite, SharedStorage};
 use crate::{consumer::Consumer, producer::Producer};
-use cache_padded::CachePadded;
 use core::{
     mem::{ManuallyDrop, MaybeUninit},
     num::NonZeroUsize,
     ptr,
     sync::atomic::{AtomicUsize, Ordering},
 };
+use crossbeam_utils::CachePadded;
 
 #[cfg(feature = "alloc")]
 use alloc::sync::Arc;


### PR DESCRIPTION
We are planning on deprecating `cache-padded` in favor of `crossbeam-utils`, see smol-rs/cache-padded#10. This PR replaces `cache-padded` with `crossbeam-utils`.