### PR TITLE
producer: Implement core::fmt::Write for Producer<u8, R>

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -277,3 +277,17 @@ where
         Ok(())
     }
 }
+
+impl<R: RbRef> core::fmt::Write for Producer<u8, R>
+where
+    R::Rb: RbWrite<u8>,
+{
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let n = self.push_slice(s.as_bytes());
+        if n != s.len() {
+            Err(core::fmt::Error::default())
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/src/tests/core_write.rs
+++ b/src/tests/core_write.rs
@@ -1,0 +1,69 @@
+use crate::StaticRb;
+use core::fmt::Write;
+
+#[test]
+fn write() {
+    let mut buf = StaticRb::<u8, 80>::default();
+
+    let (mut prod, mut cons) = buf.split_ref();
+
+    assert_eq!(write!(prod, "Hello world!\n"), Ok(()));
+    assert_eq!(write!(prod, "The answer is {}\n", 42), Ok(()));
+
+    assert_eq!(cons.len(), 30);
+    assert_eq!(cons.pop(), Some(b'H'));
+    assert_eq!(cons.pop(), Some(b'e'));
+    assert_eq!(cons.pop(), Some(b'l'));
+    assert_eq!(cons.pop(), Some(b'l'));
+    assert_eq!(cons.pop(), Some(b'o'));
+}
+
+#[test]
+fn write_overflow() {
+    let mut buf = StaticRb::<u8, 10>::default();
+
+    let (mut prod, mut cons) = buf.split_ref();
+
+    assert_eq!(
+        write!(
+            prod,
+            "This is a very long string that will overflow the small buffer\n"
+        ),
+        Err(core::fmt::Error::default())
+    );
+
+    assert_eq!(cons.len(), 10);
+    assert_eq!(cons.pop(), Some(b'T'));
+    assert_eq!(cons.pop(), Some(b'h'));
+    assert_eq!(cons.pop(), Some(b'i'));
+    assert_eq!(cons.pop(), Some(b's'));
+    assert_eq!(cons.pop(), Some(b' '));
+    assert_eq!(cons.pop(), Some(b'i'));
+    assert_eq!(cons.pop(), Some(b's'));
+    assert_eq!(cons.pop(), Some(b' '));
+    assert_eq!(cons.pop(), Some(b'a'));
+    assert_eq!(cons.pop(), Some(b' '));
+    assert_eq!(cons.pop(), None);
+
+    assert_eq!(
+        write!(
+            prod,
+            "{} {} {} {} {}\n",
+            "This", "string", "will", "also", "overflow"
+        ),
+        Err(core::fmt::Error::default())
+    );
+
+    assert_eq!(cons.len(), 10);
+    assert_eq!(cons.pop(), Some(b'T'));
+    assert_eq!(cons.pop(), Some(b'h'));
+    assert_eq!(cons.pop(), Some(b'i'));
+    assert_eq!(cons.pop(), Some(b's'));
+    assert_eq!(cons.pop(), Some(b' '));
+    assert_eq!(cons.pop(), Some(b's'));
+    assert_eq!(cons.pop(), Some(b't'));
+    assert_eq!(cons.pop(), Some(b'r'));
+    assert_eq!(cons.pop(), Some(b'i'));
+    assert_eq!(cons.pop(), Some(b'n'));
+    assert_eq!(cons.pop(), None);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -17,3 +17,5 @@ mod slice;
 mod message;
 #[cfg(feature = "std")]
 mod read_write;
+
+mod core_write;


### PR DESCRIPTION
Implement core::fmt::Write for Producer<u8, R>. This allows the use of `write!()` in a no-std environment.

This should address https://github.com/agerasev/ringbuf/issues/11.