### PR TITLE
Fix an Error in Previous PR

### DIFF
--- a/async/src/lib.rs
+++ b/async/src/lib.rs
@@ -18,7 +18,7 @@ pub use rb::AsyncRb;
 pub use traits::{consumer, producer};
 pub use transfer::async_transfer;
 
-#[cfg(all(test, feature = "std"))]
+#[cfg(test)]
 mod tests;
 
 #[cfg(all(test, feature = "bench"))]

--- a/async/src/tests.rs
+++ b/async/src/tests.rs
@@ -1,8 +1,9 @@
 use crate::{async_transfer, traits::*, AsyncHeapRb};
+use alloc::vec::Vec;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use futures::task::{noop_waker_ref, AtomicWaker};
+#[cfg(feature = "std")]
 use std::sync::Arc;
-use std::{vec, vec::Vec};
 
 #[test]
 fn atomic_waker() {
@@ -59,7 +60,7 @@ fn push_pop_slice() {
         },
         async move {
             let mut cons = cons;
-            let mut data = vec![0; COUNT + 1];
+            let mut data = [0; COUNT + 1];
             let count = cons.pop_slice_all(&mut data).await.unwrap_err();
             assert_eq!(count, COUNT);
             assert!(data.into_iter().take(COUNT).eq(0..COUNT));
@@ -94,6 +95,7 @@ fn sink_stream() {
     );
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn read_write() {
     use futures::{AsyncReadExt, AsyncWriteExt};
@@ -167,6 +169,7 @@ fn wait() {
     );
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn drop_close_prod() {
     let (prod, mut cons) = AsyncHeapRb::<usize>::new(1).split();
@@ -189,6 +192,7 @@ fn drop_close_prod() {
     t1.join().unwrap();
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn drop_close_cons() {
     let (mut prod, mut cons) = AsyncHeapRb::<usize>::new(1).split();

--- a/async/src/traits/consumer.rs
+++ b/async/src/traits/consumer.rs
@@ -75,6 +75,7 @@ impl<'a, A: AsyncConsumer> Future for PopFuture<'a, A> {
             assert!(!self.done);
             let closed = self.owner.is_closed();
             #[cfg(feature = "std")]
+            std::println!("PopFuture::poll: closed={}", closed);
             match self.owner.try_pop() {
                 Some(item) => {
                     self.done = true;

--- a/async/src/traits/consumer.rs
+++ b/async/src/traits/consumer.rs
@@ -74,8 +74,6 @@ impl<'a, A: AsyncConsumer> Future for PopFuture<'a, A> {
         loop {
             assert!(!self.done);
             let closed = self.owner.is_closed();
-            #[cfg(feature = "std")]
-            std::println!("PopFuture::poll: closed={}", closed);
             if let Some(item) = self.owner.try_pop() {
                 self.done = true;
                 break Poll::Ready(Some(item));

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,7 @@ cargo check --no-default-features --features alloc && \
 cargo check --no-default-features && \
 cd async && \
 cargo test && \
+cargo test --no-default-features --features alloc && \
 cargo check --no-default-features --features alloc && \
 cargo check --no-default-features && \
 cd ../blocking && \


### PR DESCRIPTION
The first commit fixes a bug caused by me mistakenly deleted a `println!` after #[cfg(feature = "std")]. Quite a serious mistake!

The second commit improves the code readability a little, by flatten the nested `if else` in those polling functions.