### PR TITLE
Symlink licenses to the async crate

### DIFF
--- a/async/LICENSE-APACHE
+++ b/async/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/async/LICENSE-MIT
+++ b/async/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Makes the licenses available in the packages uploaded to crates.io from `cargo package` which helps vendoring with explicit licensing.

Motivation: I'd like to use this crate in [Fuchsia](https://fuchsia.dev) and when vendoring `async-ringbuf` from crates.io I noticed the licenses are not available there. I figure a symlink should make the packaged crate cleaner here.

Verified that `cargo package` includes both `LICENSE-APACHE` and `LICENSE-MIT`.