### PR TITLE
Use std mem size_of

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -168,7 +168,7 @@ impl<T> From<Vec<MaybeUninit<T>>> for Heap<T> {
         // Convert `value` to boxed slice of length equals to `value.capacity()`
         // except for zero-sized types - for them length will be `value.len()` because `Vec::capacity` for ZST is undefined
         // (see <https://doc.rust-lang.org/std/vec/struct.Vec.html#guarantees>).
-        if size_of::<T>() != 0 {
+        if std::mem::size_of::<T>() != 0 {
             unsafe { value.set_len(value.capacity()) };
         }
         Self::from(value.into_boxed_slice())


### PR DESCRIPTION
This fixes the compiler error. I wasn't sure if you wanted to use size_of from std::mem or core::mem. Just let me know and I'll change it. 