### PR TITLE
Use portable-atomic sync primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,14 @@ license.workspace = true
 
 [features]
 default = ["std"]
-std = ["alloc"]
+std = ["alloc", "portable-atomic/std"]
 alloc = []
 bench = []
 test_local = []
 
 [dependencies]
 crossbeam-utils = { version = "0.8", default-features = false }
+portable-atomic  = "1"
 
 [dev-dependencies]
 once_mut = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Lock-free SPSC FIFO ring buffer with direct access to inner data.
 + Different types of buffers and underlying storages.
 + Can be used without `std` and even without `alloc` (using only statically-allocated memory).
 + Async and blocking versions (see [this section](#derived-crates)).
++ Uses the `portable-atomic` crate to allow usage on smaller systems without CAS operations.
 
 # Usage
 

--- a/src/rb/shared.rs
+++ b/src/rb/shared.rs
@@ -16,9 +16,9 @@ use core::{
     mem::{ManuallyDrop, MaybeUninit},
     num::NonZeroUsize,
     ptr,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 use crossbeam_utils::CachePadded;
+use portable_atomic::{AtomicBool, AtomicUsize, Ordering};
 
 /// Ring buffer that can be shared between threads.
 ///


### PR DESCRIPTION
This allows to use the crate on really small systems like Cortex-M0 based systems, where those types are not available in the standard library