### PR TITLE
remove mut on split_ref function

### DIFF
--- a/async/src/rb.rs
+++ b/async/src/rb.rs
@@ -102,7 +102,7 @@ impl<S: Storage> SplitRef for AsyncRb<S> {
     type RefProd<'a> = AsyncProd<&'a Self> where Self:  'a;
     type RefCons<'a> = AsyncCons<&'a Self> where Self:  'a;
 
-    fn split_ref(&mut self) -> (Self::RefProd<'_>, Self::RefCons<'_>) {
+    fn split_ref(&self) -> (Self::RefProd<'_>, Self::RefCons<'_>) {
         unsafe { (AsyncProd::new(self), AsyncCons::new(self)) }
     }
 }

--- a/blocking/src/rb.rs
+++ b/blocking/src/rb.rs
@@ -98,7 +98,7 @@ impl<S: Storage, X: Semaphore> SplitRef for BlockingRb<S, X> {
     type RefProd<'a> = BlockingProd<&'a Self> where Self: 'a;
     type RefCons<'a> = BlockingCons<&'a Self> where Self: 'a;
 
-    fn split_ref(&mut self) -> (Self::RefProd<'_>, Self::RefCons<'_>) {
+    fn split_ref(&self) -> (Self::RefProd<'_>, Self::RefCons<'_>) {
         (BlockingProd::new(self), BlockingCons::new(self))
     }
 }

--- a/examples/static.rs
+++ b/examples/static.rs
@@ -4,7 +4,7 @@ use ringbuf::{traits::*, StaticRb};
 
 fn main() {
     const RB_SIZE: usize = 1;
-    let mut rb = StaticRb::<i32, RB_SIZE>::default();
+    let rb = StaticRb::<i32, RB_SIZE>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     assert_eq!(prod.try_push(123), Ok(()));

--- a/src/rb/local.rs
+++ b/src/rb/local.rs
@@ -166,7 +166,7 @@ impl<S: Storage + ?Sized> SplitRef for LocalRb<S> {
     type RefProd<'a> = Prod<&'a Self> where Self: 'a;
     type RefCons<'a> = Cons<&'a Self> where Self: 'a;
 
-    fn split_ref(&mut self) -> (Self::RefProd<'_>, Self::RefCons<'_>) {
+    fn split_ref(&self) -> (Self::RefProd<'_>, Self::RefCons<'_>) {
         (Prod::new(self), Cons::new(self))
     }
 }

--- a/src/rb/shared.rs
+++ b/src/rb/shared.rs
@@ -181,7 +181,7 @@ impl<S: Storage + ?Sized> SplitRef for SharedRb<S> {
     type RefProd<'a> = CachingProd<&'a Self> where Self: 'a;
     type RefCons<'a> = CachingCons<&'a Self> where Self: 'a;
 
-    fn split_ref(&mut self) -> (Self::RefProd<'_>, Self::RefCons<'_>) {
+    fn split_ref(&self) -> (Self::RefProd<'_>, Self::RefCons<'_>) {
         (CachingProd::new(self), CachingCons::new(self))
     }
 }

--- a/src/tests/access.rs
+++ b/src/tests/access.rs
@@ -4,7 +4,7 @@ use core::mem::MaybeUninit;
 
 #[test]
 fn try_push() {
-    let mut rb = Rb::<Array<i32, 3>>::default();
+    let rb = Rb::<Array<i32, 3>>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     let vs_20 = (123, 456);
@@ -47,7 +47,7 @@ fn try_push() {
 #[test]
 fn pop_full() {
     const CAP: usize = 2;
-    let mut rb = Rb::<Array<i32, CAP>>::default();
+    let rb = Rb::<Array<i32, CAP>>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     for i in 0..CAP {
@@ -71,7 +71,7 @@ fn pop_full() {
 
 #[test]
 fn pop_empty() {
-    let mut rb = Rb::<Array<i32, 2>>::default();
+    let rb = Rb::<Array<i32, 2>>::default();
     let (_, cons) = rb.split_ref();
 
     {
@@ -84,7 +84,7 @@ fn pop_empty() {
 
 #[test]
 fn try_pop() {
-    let mut rb = Rb::<Array<i32, 3>>::default();
+    let rb = Rb::<Array<i32, 3>>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     let vs_20 = (123, 456, 789);
@@ -133,7 +133,7 @@ fn try_pop() {
 
 #[test]
 fn push_return() {
-    let mut rb = Rb::<Array<i32, 2>>::default();
+    let rb = Rb::<Array<i32, 2>>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     {
@@ -166,7 +166,7 @@ fn push_return() {
 
 #[test]
 fn pop_return() {
-    let mut rb = Rb::<Array<i32, 2>>::default();
+    let rb = Rb::<Array<i32, 2>>::default();
     let (mut prod, cons) = rb.split_ref();
 
     assert_eq!(prod.try_push(12), Ok(()));
@@ -201,7 +201,7 @@ fn pop_return() {
 
 #[test]
 fn push_pop() {
-    let mut rb = Rb::<Array<i32, 3>>::default();
+    let rb = Rb::<Array<i32, 3>>::default();
     let (mut prod, cons) = rb.split_ref();
 
     let vs_20 = (123, 456);

--- a/src/tests/basic.rs
+++ b/src/tests/basic.rs
@@ -14,7 +14,7 @@ fn capacity() {
 #[test]
 fn split_capacity() {
     const CAP: usize = 13;
-    let mut rb = Rb::<Array<i32, CAP>>::default();
+    let rb = Rb::<Array<i32, CAP>>::default();
     let (prod, cons) = rb.split_ref();
 
     assert_eq!(prod.capacity().get(), CAP);
@@ -23,7 +23,7 @@ fn split_capacity() {
 
 #[test]
 fn try_push() {
-    let mut rb = Rb::<Array<i32, 2>>::default();
+    let rb = Rb::<Array<i32, 2>>::default();
     let (mut prod, _) = rb.split_ref();
 
     assert_eq!(indices(prod.observe()), (0, 0));
@@ -40,7 +40,7 @@ fn try_push() {
 
 #[test]
 fn pop_empty() {
-    let mut rb = Rb::<Array<i32, 2>>::default();
+    let rb = Rb::<Array<i32, 2>>::default();
     let (_, mut cons) = rb.split_ref();
 
     assert_eq!(indices(cons.observe()), (0, 0));
@@ -52,7 +52,7 @@ fn pop_empty() {
 #[test]
 fn push_pop_one() {
     const CAP: usize = 2;
-    let mut rb = Rb::<Array<i32, CAP>>::default();
+    let rb = Rb::<Array<i32, CAP>>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     const MOD: usize = 2 * CAP;
@@ -74,7 +74,7 @@ fn push_pop_one() {
 #[test]
 fn push_pop_all() {
     const CAP: usize = 2;
-    let mut rb = Rb::<Array<i32, CAP>>::default();
+    let rb = Rb::<Array<i32, CAP>>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     const MOD: usize = 2 * CAP;
@@ -104,7 +104,7 @@ fn push_pop_all() {
 
 #[test]
 fn empty_full() {
-    let mut rb = Rb::<Array<i32, 1>>::default();
+    let rb = Rb::<Array<i32, 1>>::default();
     let (mut prod, cons) = rb.split_ref();
 
     assert!(prod.is_empty());
@@ -122,7 +122,7 @@ fn empty_full() {
 
 #[test]
 fn len_remaining() {
-    let mut rb = Rb::<Array<i32, 2>>::default();
+    let rb = Rb::<Array<i32, 2>>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     assert_eq!(prod.occupied_len(), 0);

--- a/src/tests/drop.rs
+++ b/src/tests/drop.rs
@@ -18,7 +18,7 @@ impl<'a> Dropper<'a> {
     }
 }
 
-impl<'a> Drop for Dropper<'a> {
+impl Drop for Dropper<'_> {
     fn drop(&mut self) {
         if !self.set.borrow_mut().remove(&self.id) {
             panic!("value {} already removed", self.id);
@@ -30,7 +30,7 @@ impl<'a> Drop for Dropper<'a> {
 fn single() {
     let set = RefCell::new(BTreeSet::new());
 
-    let mut rb = Rb::<Array<Dropper, 3>>::default();
+    let rb = Rb::<Array<Dropper, 3>>::default();
 
     assert_eq!(set.borrow().len(), 0);
 
@@ -62,7 +62,7 @@ fn single() {
 fn transaction() {
     let set = RefCell::new(BTreeSet::new());
 
-    let mut rb = Rb::<Array<Dropper, 5>>::default();
+    let rb = Rb::<Array<Dropper, 5>>::default();
 
     assert_eq!(set.borrow().len(), 0);
     {

--- a/src/tests/fmt_write.rs
+++ b/src/tests/fmt_write.rs
@@ -4,7 +4,7 @@ use core::fmt::Write;
 
 #[test]
 fn write() {
-    let mut rb = Rb::<Array<u8, 40>>::default();
+    let rb = Rb::<Array<u8, 40>>::default();
 
     let (mut prod, cons) = rb.split_ref();
 
@@ -17,7 +17,7 @@ fn write() {
 
 #[test]
 fn write_overflow() {
-    let mut rb = Rb::<Array<u8, 10>>::default();
+    let rb = Rb::<Array<u8, 10>>::default();
 
     let (mut prod, mut cons) = rb.split_ref();
 

--- a/src/tests/frozen.rs
+++ b/src/tests/frozen.rs
@@ -3,7 +3,7 @@ use crate::{storage::Array, traits::*};
 
 #[test]
 fn producer() {
-    let mut rb = Rb::<Array<i32, 2>>::default();
+    let rb = Rb::<Array<i32, 2>>::default();
     let (prod, mut cons) = rb.split_ref();
     let mut frozen_prod = prod.freeze();
     frozen_prod.try_push(0).unwrap();
@@ -40,7 +40,7 @@ fn producer() {
 
 #[test]
 fn discard() {
-    let mut rb = Rb::<Array<i32, 10>>::default();
+    let rb = Rb::<Array<i32, 10>>::default();
     let (prod, cons) = rb.split_ref();
     let mut frozen_prod = prod.freeze();
     frozen_prod.try_push(0).unwrap();
@@ -78,7 +78,7 @@ fn discard() {
 
 #[test]
 fn consumer() {
-    let mut rb = Rb::<Array<i32, 10>>::default();
+    let rb = Rb::<Array<i32, 10>>::default();
     let (mut prod, cons) = rb.split_ref();
     let mut frozen_cons = cons.freeze();
     prod.try_push(0).unwrap();

--- a/src/tests/hold.rs
+++ b/src/tests/hold.rs
@@ -3,7 +3,7 @@ use crate::{storage::Array, traits::*, CachingCons, CachingProd, Obs};
 
 #[test]
 fn split_and_drop() {
-    let mut rb = Rb::<Array<i32, 2>>::default();
+    let rb = Rb::<Array<i32, 2>>::default();
     let (prod, cons) = rb.split_ref();
     let obs = prod.observe();
 

--- a/src/tests/init.rs
+++ b/src/tests/init.rs
@@ -7,7 +7,7 @@ use alloc::{boxed::Box, vec::Vec};
 
 #[test]
 fn from_array() {
-    let mut rb = Rb::from([123, 321]);
+    let rb = Rb::from([123, 321]);
     let (mut prod, mut cons) = rb.split_ref();
 
     assert_eq!(prod.capacity().get(), 2);

--- a/src/tests/iter.rs
+++ b/src/tests/iter.rs
@@ -3,7 +3,7 @@ use crate::{storage::Array, traits::*};
 
 #[test]
 fn iter() {
-    let mut rb = Rb::<Array<i32, 2>>::default();
+    let rb = Rb::<Array<i32, 2>>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     prod.try_push(10).unwrap();
@@ -19,7 +19,7 @@ fn iter() {
 
 #[test]
 fn iter_mut() {
-    let mut rb = Rb::<Array<i32, 2>>::default();
+    let rb = Rb::<Array<i32, 2>>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     prod.try_push(10).unwrap();
@@ -39,7 +39,7 @@ fn iter_mut() {
 
 #[test]
 fn pop_iter() {
-    let mut rb = Rb::<Array<i32, 3>>::default();
+    let rb = Rb::<Array<i32, 3>>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     prod.try_push(0).unwrap();
@@ -58,7 +58,7 @@ fn pop_iter() {
 
 #[test]
 fn push_pop_iter_partial() {
-    let mut rb = Rb::<Array<i32, 4>>::default();
+    let rb = Rb::<Array<i32, 4>>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     prod.try_push(0).unwrap();

--- a/src/tests/read_write.rs
+++ b/src/tests/read_write.rs
@@ -10,8 +10,8 @@ macro_rules! assert_eq_kind {
 
 #[test]
 fn from() {
-    let mut rb0 = Rb::<Array<u8, 4>>::default();
-    let mut rb1 = Rb::<Array<u8, 4>>::default();
+    let rb0 = Rb::<Array<u8, 4>>::default();
+    let rb1 = Rb::<Array<u8, 4>>::default();
     let (mut prod0, mut cons0) = rb0.split_ref();
     let (mut prod1, mut cons1) = rb1.split_ref();
 
@@ -47,8 +47,8 @@ fn from() {
 
 #[test]
 fn into() {
-    let mut rb0 = Rb::<Array<u8, 4>>::default();
-    let mut rb1 = Rb::<Array<u8, 4>>::default();
+    let rb0 = Rb::<Array<u8, 4>>::default();
+    let rb1 = Rb::<Array<u8, 4>>::default();
     let (mut prod0, mut cons0) = rb0.split_ref();
     let (mut prod1, mut cons1) = rb1.split_ref();
 
@@ -84,8 +84,8 @@ fn into() {
 
 #[test]
 fn count() {
-    let mut rb0 = Rb::<Array<u8, 4>>::default();
-    let mut rb1 = Rb::<Array<u8, 4>>::default();
+    let rb0 = Rb::<Array<u8, 4>>::default();
+    let rb1 = Rb::<Array<u8, 4>>::default();
     let (mut prod0, mut cons0) = rb0.split_ref();
     let (mut prod1, mut cons1) = rb1.split_ref();
 
@@ -123,7 +123,7 @@ fn read_from() {
         }
     }
 
-    let mut rb = Rb::<Array<u8, 4>>::default();
+    let rb = Rb::<Array<u8, 4>>::default();
     let (mut prod, mut cons) = rb.split_ref();
     prod.try_push(1).unwrap();
     assert_eq!(cons.try_pop().unwrap(), 1);

--- a/src/tests/skip.rs
+++ b/src/tests/skip.rs
@@ -5,7 +5,7 @@ use alloc::rc::Rc;
 #[test]
 fn skip() {
     // Initialize ringbuffer, prod and cons
-    let mut rb = Rb::<Array<i8, 10>>::default();
+    let rb = Rb::<Array<i8, 10>>::default();
     let (mut prod, mut cons) = rb.split_ref();
     let mut i = 0;
 
@@ -53,7 +53,7 @@ fn skip_drop() {
     let rc = Rc::<()>::new(());
 
     const CAP: usize = 10;
-    let mut rb = Rb::<Array<Rc<()>, CAP>>::default();
+    let rb = Rb::<Array<Rc<()>, CAP>>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     for _ in 0..CAP {

--- a/src/tests/slice.rs
+++ b/src/tests/slice.rs
@@ -3,7 +3,7 @@ use crate::{storage::Array, traits::*, transfer};
 
 #[test]
 fn push_pop_slice() {
-    let mut rb = Rb::<Array<i32, 4>>::default();
+    let rb = Rb::<Array<i32, 4>>::default();
     let (mut prod, mut cons) = rb.split_ref();
 
     let mut tmp = [0; 5];
@@ -28,8 +28,8 @@ fn push_pop_slice() {
 
 #[test]
 fn move_slice() {
-    let mut rb0 = Rb::<Array<i32, 4>>::default();
-    let mut rb1 = Rb::<Array<i32, 4>>::default();
+    let rb0 = Rb::<Array<i32, 4>>::default();
+    let rb1 = Rb::<Array<i32, 4>>::default();
     let (mut prod0, mut cons0) = rb0.split_ref();
     let (mut prod1, mut cons1) = rb1.split_ref();
 
@@ -62,8 +62,8 @@ fn move_slice() {
 
 #[test]
 fn move_slice_count() {
-    let mut rb0 = Rb::<Array<i32, 4>>::default();
-    let mut rb1 = Rb::<Array<i32, 4>>::default();
+    let rb0 = Rb::<Array<i32, 4>>::default();
+    let rb1 = Rb::<Array<i32, 4>>::default();
     let (mut prod0, mut cons0) = rb0.split_ref();
     let (mut prod1, mut cons1) = rb1.split_ref();
 

--- a/src/traits/split.rs
+++ b/src/traits/split.rs
@@ -23,5 +23,5 @@ pub trait SplitRef {
         Self: 'a;
 
     /// Perform splitting by reference.
-    fn split_ref(&mut self) -> (Self::RefProd<'_>, Self::RefCons<'_>);
+    fn split_ref(&self) -> (Self::RefProd<'_>, Self::RefCons<'_>);
 }


### PR DESCRIPTION
I don't know if this can be problematic I actually received this warning in clippy on the most recent stable compiler in my embedded project:

```
warning: creating a mutable reference to mutable static is discouraged
   --> flashloader/src/main.rs:155:51
    |
155 |         let (buf_prod_tc, buf_cons_tc) = unsafe { BUF_RB_TC.split_ref() };
    |                                                   ^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
```

What I am doing is basically defining a `StaticRb` like this in my RTIC based application:

```
// Ring buffers to handling variable sized telemetry
static mut RINGBUF: Lazy<StaticRb<u8, RX_RING_BUF_SIZE>> =
    Lazy::new(StaticRb::<u8, RX_RING_BUF_SIZE>::default);
```
and then splitting it like this

```
            let (data_producer, data_consumer) = unsafe { RINGBUF.split_ref() };
```

to pass the handles to different RTIC tasks. I need the unsafe because the RINGBUF has to be defined as a `static mut`.
When I received the `mut` bound from the `split_ref` function, I can use a regular `static` and I can still split the static structure.