### PR TITLE
Fix compilation on targets with no `alloc::sync::Arc` and `alloc,portable-atomic` features

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,1 @@
+{"image":"mcr.microsoft.com/devcontainers/rust:latest"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,16 @@ license.workspace = true
 
 [features]
 default = ["std"]
-std = ["alloc", "portable-atomic?/std"]
-alloc = []
+std = ["alloc", "portable-atomic?/std", "portable-atomic-util?/std"]
+portable-atomic = ["dep:portable-atomic", "dep:portable-atomic-util"]
+alloc = ["portable-atomic-util?/alloc"]
 bench = []
 test_local = []
 
 [dependencies]
 crossbeam-utils = { version = "0.8", default-features = false }
 portable-atomic = { version = "1", default-features = false, optional = true }
+portable-atomic-util = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
 lock-free-static = "0.2.1"

--- a/async/Cargo.toml
+++ b/async/Cargo.toml
@@ -15,11 +15,15 @@ resolver = "2"
 default = ["alloc", "std"]
 alloc = ["ringbuf/alloc"]
 std = ["alloc", "ringbuf/std", "futures/std"]
+portable-atomic = ["ringbuf/portable-atomic", "futures-util/portable-atomic", "dep:portable-atomic", "dep:portable-atomic-util"]
 bench = ["std"]
 
 [dependencies]
 ringbuf = { workspace = true }
 futures = { version = "0.3.30", default-features = false }
+futures-util = { version = "0.3.31", default-features = false }
+portable-atomic = { version = "1", optional = true }
+portable-atomic-util = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { version = "0.3.30", features = ["executor", "thread-pool"] }

--- a/async/src/alias.rs
+++ b/async/src/alias.rs
@@ -2,11 +2,14 @@ use crate::{
     rb::AsyncRb,
     wrap::{AsyncCons, AsyncProd},
 };
-#[cfg(feature = "alloc")]
-use alloc::sync::Arc;
 use ringbuf::{storage::Array, SharedRb};
 #[cfg(feature = "alloc")]
 use ringbuf::{storage::Heap, HeapRb};
+
+#[cfg(all(feature = "alloc", not(feature = "portable-atomic")))]
+pub use alloc::sync::Arc;
+#[cfg(all(feature = "alloc", feature = "portable-atomic"))]
+pub use portable_atomic_util::Arc;
 
 #[cfg(feature = "alloc")]
 pub type AsyncHeapRb<T> = AsyncRb<Heap<T>>;

--- a/async/src/rb.rs
+++ b/async/src/rb.rs
@@ -1,6 +1,6 @@
-use crate::wrap::{AsyncCons, AsyncProd};
 #[cfg(feature = "alloc")]
-use alloc::sync::Arc;
+use crate::alias::Arc;
+use crate::wrap::{AsyncCons, AsyncProd};
 use core::{mem::MaybeUninit, num::NonZeroUsize};
 use futures::task::AtomicWaker;
 #[cfg(feature = "alloc")]
@@ -99,8 +99,14 @@ impl<S: Storage> RingBuffer for AsyncRb<S> {
 }
 
 impl<S: Storage> SplitRef for AsyncRb<S> {
-    type RefProd<'a> = AsyncProd<&'a Self> where Self:  'a;
-    type RefCons<'a> = AsyncCons<&'a Self> where Self:  'a;
+    type RefProd<'a>
+        = AsyncProd<&'a Self>
+    where
+        Self: 'a;
+    type RefCons<'a>
+        = AsyncCons<&'a Self>
+    where
+        Self: 'a;
 
     fn split_ref(&mut self) -> (Self::RefProd<'_>, Self::RefCons<'_>) {
         unsafe { (AsyncProd::new(self), AsyncCons::new(self)) }

--- a/blocking/Cargo.toml
+++ b/blocking/Cargo.toml
@@ -12,8 +12,11 @@ license.workspace = true
 
 [features]
 default = ["std"]
-std = ["ringbuf/std", "alloc"]
 alloc = ["ringbuf/alloc"]
+std = ["ringbuf/std", "alloc"]
+portable-atomic = ["ringbuf/portable-atomic", "dep:portable-atomic", "dep:portable-atomic-util"]
 
 [dependencies]
 ringbuf = { workspace = true }
+portable-atomic = { version = "1", default-features = false, optional = true }
+portable-atomic-util = { version = "0.2", default-features = false, optional = true }

--- a/blocking/src/alias.rs
+++ b/blocking/src/alias.rs
@@ -5,6 +5,11 @@ use ringbuf::{storage::Array, SharedRb};
 #[cfg(feature = "alloc")]
 use ringbuf::{storage::Heap, HeapRb};
 
+#[cfg(all(feature = "alloc", not(feature = "portable-atomic")))]
+pub use alloc::sync::Arc;
+#[cfg(all(feature = "alloc", feature = "portable-atomic"))]
+pub use portable_atomic_util::Arc;
+
 #[cfg(feature = "std")]
 pub type BlockingHeapRb<T, X = StdSemaphore> = BlockingRb<Heap<T>, X>;
 #[cfg(all(feature = "alloc", not(feature = "std")))]

--- a/blocking/src/rb.rs
+++ b/blocking/src/rb.rs
@@ -1,8 +1,8 @@
+#[cfg(feature = "alloc")]
+use crate::alias::Arc;
 #[cfg(feature = "std")]
 use crate::sync::StdSemaphore;
 use crate::{sync::Semaphore, BlockingCons, BlockingProd};
-#[cfg(feature = "alloc")]
-use alloc::sync::Arc;
 use core::{mem::MaybeUninit, num::NonZeroUsize};
 #[cfg(feature = "alloc")]
 use ringbuf::traits::Split;
@@ -95,8 +95,14 @@ impl<S: Storage, X: Semaphore> RingBuffer for BlockingRb<S, X> {
 }
 
 impl<S: Storage, X: Semaphore> SplitRef for BlockingRb<S, X> {
-    type RefProd<'a> = BlockingProd<&'a Self> where Self: 'a;
-    type RefCons<'a> = BlockingCons<&'a Self> where Self: 'a;
+    type RefProd<'a>
+        = BlockingProd<&'a Self>
+    where
+        Self: 'a;
+    type RefCons<'a>
+        = BlockingCons<&'a Self>
+    where
+        Self: 'a;
 
     fn split_ref(&mut self) -> (Self::RefProd<'_>, Self::RefCons<'_>) {
         (BlockingProd::new(self), BlockingCons::new(self))

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,13 +6,16 @@ cargo test --features test_local && \
 cargo test --features portable-atomic && \
 cargo check --no-default-features --features alloc && \
 cargo check --no-default-features && \
+cargo check --target thumbv6m-none-eabi --no-default-features --features alloc,portable-atomic,portable-atomic/critical-section && \
 cd async && \
 cargo test && \
 cargo test --no-default-features --features alloc && \
 cargo check --no-default-features --features alloc && \
 cargo check --no-default-features && \
+cargo check --target thumbv6m-none-eabi --no-default-features --features alloc,portable-atomic,portable-atomic/critical-section && \
 cd ../blocking && \
 cargo test && \
 cargo check --no-default-features --features alloc && \
 cargo check --no-default-features && \
+cargo check --target thumbv6m-none-eabi --no-default-features --features alloc,portable-atomic,portable-atomic/critical-section && \
 echo "Done!"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+rustup target add thumbv6m-none-eabi && \
 cargo test && \
 cargo test --features test_local && \
 cargo test --features portable-atomic && \

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -5,8 +5,11 @@ use super::{
     storage::Array,
     wrap::{CachingCons, CachingProd},
 };
-#[cfg(feature = "alloc")]
-use alloc::sync::Arc;
+
+#[cfg(all(feature = "alloc", not(feature = "portable-atomic")))]
+pub use alloc::sync::Arc;
+#[cfg(all(feature = "alloc", feature = "portable-atomic"))]
+pub use portable_atomic_util::Arc;
 
 /// Stack-allocated ring buffer with static capacity.
 ///

--- a/src/rb/shared.rs
+++ b/src/rb/shared.rs
@@ -10,18 +10,19 @@ use crate::{
     },
     wrap::{CachingCons, CachingProd},
 };
-#[cfg(feature = "alloc")]
-use alloc::{boxed::Box, sync::Arc};
-#[cfg(not(feature = "portable-atomic"))]
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use core::{
     mem::{ManuallyDrop, MaybeUninit},
     num::NonZeroUsize,
     ptr,
 };
 use crossbeam_utils::CachePadded;
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 #[cfg(feature = "portable-atomic")]
 use portable_atomic::{AtomicBool, AtomicUsize, Ordering};
+#[cfg(feature = "alloc")]
+use {crate::alias::Arc, alloc::boxed::Box};
 
 /// Ring buffer that can be shared between threads.
 ///
@@ -178,8 +179,14 @@ impl<S: Storage + ?Sized> Split for Box<SharedRb<S>> {
     }
 }
 impl<S: Storage + ?Sized> SplitRef for SharedRb<S> {
-    type RefProd<'a> = CachingProd<&'a Self> where Self: 'a;
-    type RefCons<'a> = CachingCons<&'a Self> where Self: 'a;
+    type RefProd<'a>
+        = CachingProd<&'a Self>
+    where
+        Self: 'a;
+    type RefCons<'a>
+        = CachingCons<&'a Self>
+    where
+        Self: 'a;
 
     fn split_ref(&mut self) -> (Self::RefProd<'_>, Self::RefCons<'_>) {
         (CachingProd::new(self), CachingCons::new(self))

--- a/src/rb/traits.rs
+++ b/src/rb/traits.rs
@@ -1,6 +1,6 @@
 use crate::traits::RingBuffer;
 #[cfg(feature = "alloc")]
-use alloc::{rc::Rc, sync::Arc};
+use {crate::alias::Arc, alloc::rc::Rc};
 
 /// Abstract pointer to the owning ring buffer.
 ///


### PR DESCRIPTION
If you attempt to compile the crate with `alloc,portable-atomic` features on a target like `thumbv6m-none-eabi` which has no `alloc::sync::Arc` (no pointer size atomics), compilation fails. This PR fixes this by using `portable-atomic-util` on those platforms, which provides an `Arc` replacement. This also adds to `scripts/test.sh` to make sure this crate can compile on `thumbv6m-none-eabi`. The reason for picking this specific target is because Bevy also uses this as its reference "no-std/no-atomic-CAS" target.